### PR TITLE
changed rtc.js script src

### DIFF
--- a/everything.html
+++ b/everything.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>everything</title>
-    <script src="http://cdn.rawgit.com/rtc-io/rtc/v3.1.1/dist/rtc.js"></script>
+    <script src="https://cdn.jsdelivr.net/rtc/3.1.1/rtc.min.js"></script>
     <script src="everything.js"></script>
     <style>
     #flowhub_debug_url.nodebug {


### PR DESCRIPTION
Addresses the https error mentioned in https://github.com/noflo/noflo-browser/issues/6

- Kept same version (3.1.1)
- Switched to CDN (jsdelivr) they recommend in the readme https://github.com/rtc-io/rtc/#getting-started
- Forced https:// because protocol-relative urls are considered an anti-pattern https://www.paulirish.com/2010/the-protocol-relative-url/